### PR TITLE
Mark WorkingMemoryTask as Serializable.

### DIFF
--- a/drools-core/src/main/java/org/drools/core/metadata/WorkingMemoryTask.java
+++ b/drools-core/src/main/java/org/drools/core/metadata/WorkingMemoryTask.java
@@ -1,6 +1,8 @@
 package org.drools.core.metadata;
 
-public interface WorkingMemoryTask<T> extends MetaCallableTask<T>, Identifiable {
+import java.io.Serializable;
+
+public interface WorkingMemoryTask<T> extends MetaCallableTask<T>, Identifiable, Serializable {
 
     public Object getTargetId();
 


### PR DESCRIPTION
Mark WorkingMemory as Serializable for the persistence and retrieval of sessions.